### PR TITLE
Fixed race condition crash. 

### DIFF
--- a/Source/Core/MeshBuffer.cpp
+++ b/Source/Core/MeshBuffer.cpp
@@ -117,9 +117,6 @@ MeshBuffer::BufferBlock * MeshBuffer::AllocateBufferBlockAndStore(
 	VkDeviceSize								index_portion_byte_size
 )
 {
-	// TODO: make sure buffers are reserved with more memory if mesh exceeds the size of the buffer,
-	// TODO: This may introduce gaps in the buffer blocks as the last mesh should be last on the list,
-	// consider a trimming function to remove the possible empty buffer blocks in the middle.
 	auto block = std::make_unique<MeshBuffer::BufferBlock>(
 		this,
 		vertex_portion_byte_size,
@@ -149,7 +146,8 @@ void MeshBuffer::FreeBufferBlockFromStorage(
 
 MeshBuffer::ReserveSpaceResult MeshBuffer::ReserveSpaceForMesh(
 	uint32_t				vertex_count,
-	uint32_t				index_count )
+	uint32_t				index_count
+)
 {
 	VkDeviceSize vertex_byte_size			= VkDeviceSize( vertex_count ) * sizeof( Vertex );
 	VkDeviceSize index_byte_size			= VkDeviceSize( index_count ) * sizeof( uint32_t );

--- a/Source/Header/Core/ThreadPrivateResources.h
+++ b/Source/Header/Core/ThreadPrivateResources.h
@@ -10,37 +10,40 @@ namespace _internal {
 
 class RendererImpl;
 class DescriptorAutoPool;
+class DeviceMemoryPool;
 
 
 
 class ThreadLoaderResource : public ThreadPrivateResource {
 public:
 	ThreadLoaderResource(
-		RendererImpl * parent
+		vk2d::_internal::RendererImpl * parent
 	);
 
 	~ThreadLoaderResource()
 	{}
 
-	RendererImpl							*	GetRenderer() const;
-	VkDevice									GetVulkanDevice() const;
-	DescriptorAutoPool						*	GetDescriptorAutoPool() const;
-	VkCommandPool								GetPrimaryRenderCommandPool() const;
-	VkCommandPool								GetSecondaryRenderCommandPool() const;
-	VkCommandPool								GetPrimaryTransferCommandPool() const;
+	vk2d::_internal::RendererImpl							*	GetRenderer() const;
+	VkDevice													GetVulkanDevice() const;
+	vk2d::_internal::DeviceMemoryPool						*	GetDeviceMemoryPool() const;
+	vk2d::_internal::DescriptorAutoPool						*	GetDescriptorAutoPool() const;
+	VkCommandPool												GetPrimaryRenderCommandPool() const;
+	VkCommandPool												GetSecondaryRenderCommandPool() const;
+	VkCommandPool												GetPrimaryTransferCommandPool() const;
 
 protected:
-	bool										ThreadBegin();
-	void										ThreadEnd();
+	bool														ThreadBegin();
+	void														ThreadEnd();
 
 private:
-	RendererImpl							*	parent								= {};
-	VkDevice									device								= {};
-	std::unique_ptr<DescriptorAutoPool>			descriptor_auto_pool				= {};
+	vk2d::_internal::RendererImpl							*	renderer							= {};
+	VkDevice													device								= {};
+	std::unique_ptr<vk2d::_internal::DescriptorAutoPool>		descriptor_auto_pool				= {};
+	std::unique_ptr<vk2d::_internal::DeviceMemoryPool>			device_memory_pool					= {};
 
-	VkCommandPool								primary_render_command_pool			= {};
-	VkCommandPool								secondary_render_command_pool		= {};
-	VkCommandPool								primary_transfer_command_pool		= {};
+	VkCommandPool												primary_render_command_pool			= {};
+	VkCommandPool												secondary_render_command_pool		= {};
+	VkCommandPool												primary_transfer_command_pool		= {};
 };
 
 

--- a/Source/Impl/ResourceManagerImpl.cpp
+++ b/Source/Impl/ResourceManagerImpl.cpp
@@ -113,6 +113,7 @@ TextureResource * ResourceManagerImpl::CreateTextureResource(
 	uint32_t							size_y,
 	const std::vector<uint8_t>		&	texture_data )
 {
+	assert( 0 );
 	return nullptr;
 }
 

--- a/Source/Impl/TextureResourceImpl.cpp
+++ b/Source/Impl/TextureResourceImpl.cpp
@@ -54,7 +54,7 @@ bool TextureResourceImpl::MTLoad(
 	// 9. Allocate descriptor set that points to the image.
 
 	loader_thread_resource	= dynamic_cast<ThreadLoaderResource*>( thread_resource );
-	auto memory_pool		= resource_manager->GetRenderer()->GetDeviceMemoryPool();
+	auto memory_pool		= loader_thread_resource->GetDeviceMemoryPool();
 
 	assert( loader_thread_resource );
 	if( !loader_thread_resource ) return false;
@@ -732,7 +732,7 @@ void TextureResourceImpl::MTUnload(
 	assert( loader_thread_resource );
 	if( !loader_thread_resource ) return;
 
-	auto memory_pool		= resource_manager->GetRenderer()->GetDeviceMemoryPool();
+	auto memory_pool		= loader_thread_resource->GetDeviceMemoryPool();
 
 	// Check if loaded successfully, no need to check for failure as this thread was
 	// responsible for loading it, it's either loaded or failed to load but it'll

--- a/Tests/Test01/Main.cpp
+++ b/Tests/Test01/Main.cpp
@@ -18,7 +18,6 @@ int main()
 	if( !renderer ) return -1;
 
 	auto texture			= renderer->GetResourceManager()->LoadTextureResource( "../../TestData/GrafGear_128.png" );
-	texture->WaitUntilLoaded();
 
 	vk2d::WindowCreateInfo window_create_info {};
 	window_create_info.width	= 800;


### PR DESCRIPTION
Where only one DeviceMemoryPool object was used between all threads. Now each thread has their own DeviceMemoryPool and resources should use that instead.